### PR TITLE
feat: expose partial rendering entry points

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 jest.config.js
 src/types
+*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,7 +75,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/**/*.test.ts', 'test/**/*.ts'],
+      files: ['**/*.test.ts', 'test/expect.ts'],
       env: {
         'jest/globals': true,
       },

--- a/README.md
+++ b/README.md
@@ -97,3 +97,44 @@ async function renderAndDoSomethingWithPDF(
   // …
 }
 ```
+
+### Separate ballot document creation from PDF rendering
+
+Sometimes it's useful to be able to separate the ballot document creation step
+from the PDF rendering step. For example, you may wish to generate the ballot
+document in a client and send it to a server for rendering. Here's how you can
+achieve that:
+
+```ts
+// client (e.g. a browser)
+import ballotToDocument from '@votingworks/ballot-renderer/renderers/ballotToDocument'
+
+async function renderPDF(): Promise<Blob> {
+  const response = await fetch('http://localhost:8080/my/render/endpoint', {
+    method: 'POST',
+    body: JSON.stringify(ballotToDocument(completedBallot)),
+  })
+
+  return response.blob()
+}
+
+// server (e.g. nodejs + express)
+import documentToPdf from '@votingworks/ballot-renderer/renderers/documentToPdf'
+import express from 'express'
+
+const app = express()
+
+app.post('/my/render/endpoint', async (req, res) => {
+  const { body } = req
+  const json = new TextDecoder().decode(body)
+  const document = JSON.parse(json)
+  const pdf = await documentToPdf(document)
+
+  res.end(pdf)
+})
+
+app.listen(8080)
+```
+
+See the [renderers](./renderers) folder for all the partial renderings you can
+do.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  testMatch: ['<rootDir>/{src,renderers}/**/*.test.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/expect.ts'],
-  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  collectCoverageFrom: ['src/**/*.ts', 'renderers/**/*.ts', '!**/*.d.ts'],
   coverageThreshold: {
     global: {
       statements: 100,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.{ts,js}' --report-unused-disable-directives",
+    "lint": "eslint '{src,test,renderers,scripts}/**/*.ts' --report-unused-disable-directives",
     "prepare": "in-publish && tsc || not-in-publish",
     "test": "jest",
     "test:ci": "jest --ci --collectCoverage",

--- a/renderers/ballotToDocument.test.ts
+++ b/renderers/ballotToDocument.test.ts
@@ -1,0 +1,15 @@
+import makeBallot from '../src/components/ballot'
+import completedBallot from '../test/fixtures/completedBallot'
+import mockOf from '../test/utils/mockOf'
+import ballotToDocument from './ballotToDocument'
+
+jest.mock('../src/components/ballot')
+
+const makeBallotMock = mockOf(makeBallot)
+
+test('creates a pdfmake document from a completed ballot', () => {
+  makeBallotMock.mockReturnValueOnce({ text: 'Official Ballot?' })
+  expect(ballotToDocument(completedBallot)).toMatchObject({
+    content: [{ text: 'Official Ballot?' }],
+  })
+})

--- a/renderers/ballotToDocument.ts
+++ b/renderers/ballotToDocument.ts
@@ -1,0 +1,21 @@
+import { CompletedBallot } from '@votingworks/ballot-encoder'
+import * as pdfMake from 'pdfmake/build/pdfmake'
+import makeBallot from '../src/components/ballot'
+import DefaultStyleSheet from '../src/styles/themes/default'
+
+/**
+ * Convert a completed ballot to a pdfmake document, ready to be rendered.
+ */
+export default function ballotToDocument(
+  ballot: CompletedBallot,
+  styles = DefaultStyleSheet
+): pdfMake.TDocumentDefinitions {
+  return {
+    pageSize: 'LETTER' as pdfMake.PageSize,
+    content: [makeBallot(ballot)],
+    defaultStyle: {
+      font: 'HelveticaNeue',
+    },
+    styles,
+  }
+}

--- a/renderers/ballotToPdf.test.ts
+++ b/renderers/ballotToPdf.test.ts
@@ -1,0 +1,20 @@
+import ballotToPdf from './ballotToPdf'
+import completedBallot from '../test/fixtures/completedBallot'
+import ballotToDocument from './ballotToDocument'
+import mockOf from '../test/utils/mockOf'
+
+jest.mock('./ballotToDocument')
+
+const ballotToDocumentMock = mockOf(ballotToDocument)
+
+test('creates a PDF buffer based on a completed ballot using ballotToDocument', async () => {
+  ballotToDocumentMock.mockReturnValueOnce({
+    content: [{ text: 'Official Ballot?' }],
+    defaultStyle: {
+      font: 'HelveticaNeue',
+    },
+  })
+
+  // Returns a different-every-time `Buffer`, which we can't meaningfully check.
+  await ballotToPdf(completedBallot)
+})

--- a/renderers/ballotToPdf.ts
+++ b/renderers/ballotToPdf.ts
@@ -1,0 +1,14 @@
+import { CompletedBallot } from '@votingworks/ballot-encoder'
+import DefaultStyleSheet from '../src/styles/themes/default'
+import ballotToPdfRenderer from './ballotToPdfRenderer'
+import pdfRendererToPdf from './pdfRendererToPdf'
+
+/**
+ * Convert a completed ballot to a fully-rendered PDF buffer.
+ */
+export default async function ballotToPdf(
+  ballot: CompletedBallot,
+  styles = DefaultStyleSheet
+): Promise<Buffer> {
+  return pdfRendererToPdf(ballotToPdfRenderer(ballot, styles))
+}

--- a/renderers/ballotToPdfRenderer.test.ts
+++ b/renderers/ballotToPdfRenderer.test.ts
@@ -1,0 +1,20 @@
+import DefaultStyleSheet from '../src/styles/themes/default'
+import completedBallot from '../test/fixtures/completedBallot'
+import mockOf from '../test/utils/mockOf'
+import ballotToDocument from './ballotToDocument'
+import ballotToPdfRenderer from './ballotToPdfRenderer'
+
+jest.mock('./ballotToDocument')
+
+const ballotToDocumentMock = mockOf(ballotToDocument)
+
+test('creates a PDF renderer from a completed ballot by converting to a document first', () => {
+  ballotToDocumentMock.mockReturnValueOnce({ content: [] })
+
+  ballotToPdfRenderer(completedBallot, DefaultStyleSheet)
+
+  expect(ballotToDocumentMock).toHaveBeenCalledWith(
+    completedBallot,
+    DefaultStyleSheet
+  )
+})

--- a/renderers/ballotToPdfRenderer.ts
+++ b/renderers/ballotToPdfRenderer.ts
@@ -1,0 +1,17 @@
+import * as pdfMake from 'pdfmake/build/pdfmake'
+import { CompletedBallot } from '@votingworks/ballot-encoder'
+import DefaultStyleSheet from '../src/styles/themes/default'
+import ballotToDocument from './ballotToDocument'
+import documentToPdfRenderer from './documentToPdfRenderer'
+
+/**
+ * Convert a completed ballot to a pdfmake renderer. This is one step before
+ * creating a fully-rendered PDF document, and is useful if you want to get the
+ * PDF in a format other than a `Buffer`.
+ */
+export default function ballotToPdfRenderer(
+  ballot: CompletedBallot,
+  styles = DefaultStyleSheet
+): pdfMake.TCreatedPdf {
+  return documentToPdfRenderer(ballotToDocument(ballot, styles))
+}

--- a/renderers/documentToPdf.test.ts
+++ b/renderers/documentToPdf.test.ts
@@ -1,0 +1,16 @@
+import * as pdfMake from 'pdfmake/build/pdfmake'
+import mockOf from '../test/utils/mockOf'
+import documentToPdfRenderer from './documentToPdfRenderer'
+import documentToPdf from './documentToPdf'
+
+jest.mock('./documentToPdfRenderer')
+
+const documentToPdfRendererMock = mockOf(documentToPdfRenderer)
+
+test('creates a PDF document buffer from a document', async () => {
+  documentToPdfRendererMock.mockReturnValueOnce({
+    getBuffer: callback => callback(Buffer.of(1, 2, 3), []),
+  } as pdfMake.TCreatedPdf)
+
+  expect(await documentToPdf({ content: [] })).toEqual(Buffer.of(1, 2, 3))
+})

--- a/renderers/documentToPdf.ts
+++ b/renderers/documentToPdf.ts
@@ -1,0 +1,12 @@
+import * as pdfMake from 'pdfmake/build/pdfmake'
+import documentToPdfRenderer from './documentToPdfRenderer'
+import pdfRendererToPdf from './pdfRendererToPdf'
+
+/**
+ * Convert a pdfmake document to a fully-rendered PDF document buffer.
+ */
+export default async function documentToPdf(
+  document: pdfMake.TDocumentDefinitions
+): Promise<Buffer> {
+  return pdfRendererToPdf(documentToPdfRenderer(document))
+}

--- a/renderers/documentToPdfRenderer.test.ts
+++ b/renderers/documentToPdfRenderer.test.ts
@@ -1,0 +1,5 @@
+import documentToPdfRenderer from './documentToPdfRenderer'
+
+test('creates a PDF renderer from PDF make', () => {
+  expect(documentToPdfRenderer({ content: [] })).toBeTruthy()
+})

--- a/renderers/documentToPdfRenderer.ts
+++ b/renderers/documentToPdfRenderer.ts
@@ -1,0 +1,9 @@
+import * as pdfMake from 'pdfmake/build/pdfmake'
+import fonts from '../src/data/fonts.json'
+import vfs from '../src/data/vfs.json'
+
+export default function documentToPdfRenderer(
+  document: pdfMake.TDocumentDefinitions
+): pdfMake.TCreatedPdf {
+  return pdfMake.createPdf(document, undefined, fonts, vfs)
+}

--- a/renderers/pdfRendererToPdf.test.ts
+++ b/renderers/pdfRendererToPdf.test.ts
@@ -1,0 +1,10 @@
+import * as pdfMake from 'pdfmake/build/pdfmake'
+import pdfRendererToPdf from './pdfRendererToPdf'
+
+test('builds a PDF buffer from a PDF renderer', async () => {
+  const renderer = {
+    getBuffer: callback => callback(Buffer.of(1, 2, 3), []),
+  } as pdfMake.TCreatedPdf
+
+  expect(await pdfRendererToPdf(renderer)).toEqual(Buffer.of(1, 2, 3))
+})

--- a/renderers/pdfRendererToPdf.ts
+++ b/renderers/pdfRendererToPdf.ts
@@ -1,0 +1,9 @@
+import * as pdfMake from 'pdfmake/build/pdfmake'
+
+export default async function pdfRendererToPdf(
+  renderer: pdfMake.TCreatedPdf
+): Promise<Buffer> {
+  return new Promise((resolve): void => {
+    renderer.getBuffer(data => resolve(data))
+  })
+}

--- a/scripts/build-fonts.ts
+++ b/scripts/build-fonts.ts
@@ -57,6 +57,7 @@ async function build(): Promise<void> {
 }
 
 build().catch(error => {
+  // eslint-disable-next-line no-console
   console.error(error.stack)
   process.exitCode = 1
 })

--- a/scripts/render.ts
+++ b/scripts/render.ts
@@ -1,27 +1,31 @@
 import * as fs from 'fs'
 import { join } from 'path'
 import { promisify } from 'util'
-import render, { renderAsPdf, renderAsPdfContent } from '../src'
-import DefaultStyleSheet from '../src/styles/themes/default'
+import {
+  ballotToDocument,
+  documentToPdfRenderer,
+  pdfRendererToPdf,
+} from '../src'
 import completedBallot from '../test/fixtures/completedBallot'
 
 const writeFile = promisify(fs.writeFile)
 
 async function main(): Promise<void> {
-  const pdfContent = renderAsPdfContent(completedBallot)
+  const document = ballotToDocument(completedBallot)
 
   await writeFile(
     join(__dirname, '..', 'output.pdf.json'),
-    JSON.stringify(pdfContent, undefined, 2)
+    JSON.stringify(document, undefined, 2)
   )
 
-  const pdf = renderAsPdf(completedBallot, DefaultStyleSheet, pdfContent)
-  const rendered = await render(completedBallot, DefaultStyleSheet, pdf)
+  const pdfRenderer = documentToPdfRenderer(document)
+  const rendered = await pdfRendererToPdf(pdfRenderer)
 
   await writeFile(join(__dirname, '..', 'output.pdf'), rendered)
 }
 
 main().catch(error => {
+  // eslint-disable-next-line no-console
   console.error(error.stack)
   process.exitCode = 1
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,16 +1,16 @@
-import { renderAsPdfContent, renderAsPdf, renderAsBuffer } from '.'
+import { ballotToDocument, ballotToPdfRenderer, ballotToPdf } from '.'
 import completedBallot from '../test/fixtures/completedBallot'
 
 test('can render to a buffer', async () => {
-  expect(await renderAsBuffer(completedBallot)).toBeInstanceOf(Uint8Array)
+  expect(await ballotToPdf(completedBallot)).toBeInstanceOf(Uint8Array)
 })
 
-test('can render to PDF content', () => {
-  expect(renderAsPdfContent(completedBallot)).toMatchObject({
+test('can render to PDF document', () => {
+  expect(ballotToDocument(completedBallot)).toMatchObject({
     content: expect.any(Array),
   })
 })
 
-test('can render to makePdf object', () => {
-  expect(renderAsPdf(completedBallot)).not.toBeInstanceOf(Uint8Array)
+test('can render to PDF renderer', () => {
+  expect(ballotToPdfRenderer(completedBallot)).not.toBeInstanceOf(Uint8Array)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,10 @@
-import { CompletedBallot } from '@votingworks/ballot-encoder'
-import * as pdfMake from 'pdfmake/build/pdfmake'
-import makeBallot from './components/ballot'
-import fonts from './data/fonts.json'
-import vfs from './data/vfs.json'
-import DefaultStyleSheet from './styles/themes/default'
-
-export async function renderAsBuffer(
-  ballot: CompletedBallot,
-  styles = DefaultStyleSheet,
-  pdf = renderAsPdf(ballot, styles)
-): Promise<Buffer> {
-  return new Promise((resolve): void => {
-    pdf.getBuffer(data => resolve(data))
-  })
-}
-
-export function renderAsPdf(
-  ballot: CompletedBallot,
-  styles = DefaultStyleSheet,
-  content = renderAsPdfContent(ballot, styles)
-): pdfMake.TCreatedPdf {
-  return pdfMake.createPdf(content, undefined, fonts, vfs)
-}
-
-export function renderAsPdfContent(
-  ballot: CompletedBallot,
-  styles = DefaultStyleSheet
-): pdfMake.TDocumentDefinitions {
-  return {
-    pageSize: 'LETTER' as pdfMake.PageSize,
-    content: [makeBallot(ballot)],
-    defaultStyle: {
-      font: 'HelveticaNeue',
-    },
-    styles,
-  }
-}
-
-export default renderAsBuffer
+export { default as ballotToDocument } from '../renderers/ballotToDocument'
+export { default as ballotToPdf, default } from '../renderers/ballotToPdf'
+export {
+  default as ballotToPdfRenderer,
+} from '../renderers/ballotToPdfRenderer'
+export { default as documentToPdf } from '../renderers/documentToPdf'
+export {
+  default as documentToPdfRenderer,
+} from '../renderers/documentToPdfRenderer'
+export { default as pdfRendererToPdf } from '../renderers/pdfRendererToPdf'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "strict": true,
     "target": "es2015"
   },
-  "include": ["src", "scripts", "test"]
+  "include": ["src", "renderers", "scripts", "test"]
 }


### PR DESCRIPTION

This allows separating the creating of a PDF description document from the rendering of the actual PDF itself, mostly to allow a client/server separation of responsibilities.